### PR TITLE
Added an icon to the AnimationSequencer monobehaviour

### DIFF
--- a/Scripts/Runtime/Core/AnimationSequencer.cs.meta
+++ b/Scripts/Runtime/Core/AnimationSequencer.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: -6866312847677126049, guid: 0000000000000000d000000000000000, type: 0}
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
This pull request adds an icon to the monobehaviour. It's a small thing, but in my project I have a lot of components so being able to quickly identify them visually is handy. I have used the built-in icon `d_Animation Icon` but can switch it to whatever you'd like. I found a full list of icons here:

https://github.com/halak/unity-editor-icons